### PR TITLE
Bump rollbar to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/goodeggs/rollbar-stream",
   "bugs": "https://github.com/goodeggs/rollbar-stream/issues",
   "dependencies": {
-    "rollbar": "^0.5.6",
+    "rollbar": "^0.6.2",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/test/rollbar_stream.test.coffee
+++ b/test/rollbar_stream.test.coffee
@@ -48,8 +48,8 @@ describe 'RollbarStream', ->
         item = rollbar.api.postItem.lastCall.args[0]
 
       it 'sets the error', ->
-        expect(item.body.trace.exception.message).to.equal 'some error message'
-        expect(item.body.trace.exception.class).to.equal 'Error'
+        expect(item.body.trace_chain[0].exception.message).to.equal 'some error message'
+        expect(item.body.trace_chain[0].exception.class).to.equal 'Error'
 
       it 'sets the person', ->
         expect(item.person.email).to.equal user.email


### PR DESCRIPTION
_sigh_ why is this module still in beta?

https://github.com/rollbar/node_rollbar/blob/master/CHANGELOG.md
