### PR TITLE
Allow setting custom rollbar fingerprints in write()

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,7 +16,7 @@ class RollbarStream extends stream.Stream
       rollbar
 
   write: (obj, cb) ->
-    customData = _(obj).omit('msg', 'err', 'req')
+    customData = _(obj).omit('msg', 'err', 'req', 'fingerprint')
 
     if obj.err?
       rebuiltErr = RollbarStream.rebuildErrorForReporting(obj.err)
@@ -36,6 +36,8 @@ class RollbarStream extends stream.Stream
     data =
       custom: customData
       title: obj.msg if obj.msg?
+
+    data.fingerprint = obj.fingerprint if obj.fingerprint?
 
     @client.handleErrorWithPayloadData err, data, req, (e2) ->
       process.stderr.write util.format.call(util, 'Error logging to Rollbar', e2.stack or e2) + "\n" if e2?

--- a/test/rollbar_stream.test.coffee
+++ b/test/rollbar_stream.test.coffee
@@ -68,6 +68,25 @@ describe 'RollbarStream', ->
         expect(item.foobar).to.be.undefined
         expect(item.custom).to.eql level: 20, hello: 'world', error: { data: { field: 'extra data from boom' }, foobar: 'baz' }
 
+    describe 'an error with a custom fingerprint', ->
+
+      beforeEach ->
+        sinon.stub(rollbar, 'handleErrorWithPayloadData').yields()
+
+      afterEach ->
+        rollbar.handleErrorWithPayloadData.restore()
+
+      it 'passes through the fingerprint to rollbar', fibrous ->
+        stream.sync.write {
+          msg: 'something I want to fingerpint',
+          fingerprint: '123'
+        }
+        expect(rollbar.handleErrorWithPayloadData.lastCall.args[1]).to.deep.equal {
+          custom: {}
+          title: 'something I want to fingerpint'
+          fingerprint: '123'
+        }
+
   describe 'RollbarStream.rebuildErrorForReporting', ->
 
     it 'rewrites fibrous stacks so stack parsers can grok it ', fibrous ->


### PR DESCRIPTION
Paired with @arlo-egg. We wanted to control the grouping of rollbar messages in our application logic. Rollbar supports this, but requires us to pass through the fingerprint used for grouping. See the [rollbar docs](https://rollbar.com/docs/grouping-algorithm/#customizing-grouping-in-code).

cc @goodeggs/shopping-web @goodeggs/ops-tools 