### PR TITLE
Upgrade rollbar to 2.3.9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/goodeggs/rollbar-stream",
   "bugs": "https://github.com/goodeggs/rollbar-stream/issues",
   "dependencies": {
-    "rollbar": "^2.2.10",
+    "rollbar": "2.3.9",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,9 +196,9 @@ request-ip@~2.0.1:
   dependencies:
     is_js "^0.9.0"
 
-rollbar@^2.2.10:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.3.2.tgz#2c148be59e55ecdfe1beee5d7f3c3d0203e5dc76"
+rollbar@2.3.9:
+  version "2.3.9"
+  resolved "https://registry.npmjs.org/rollbar/-/rollbar-2.3.9.tgz#46dc6c5531177ae282c8622ad8e930dad9cf2305"
   dependencies:
     async "~1.2.1"
     console-polyfill "0.3.0"


### PR DESCRIPTION
Makes the `verbose` option actually sensible: https://github.com/rollbar/rollbar.js/pull/581.

fyi @bobzoller