### PR TITLE
Updates rollbar to 2.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/goodeggs/rollbar-stream",
   "bugs": "https://github.com/goodeggs/rollbar-stream/issues",
   "dependencies": {
-    "rollbar": "2.3.9",
+    "rollbar": "^2.4.7",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,10 +71,6 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-extend@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
-
 fibers@>=0.6.7:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fibers/-/fibers-2.0.0.tgz#f26d0aaf1f99995fbe1cb3f340efac08bda9dc4b"
@@ -196,15 +192,14 @@ request-ip@~2.0.1:
   dependencies:
     is_js "^0.9.0"
 
-rollbar@2.3.9:
-  version "2.3.9"
-  resolved "http://registry.npmjs.org/rollbar/-/rollbar-2.3.9.tgz#46dc6c5531177ae282c8622ad8e930dad9cf2305"
+rollbar@^2.4.7:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.4.7.tgz#9b1de1a0fab6b6e63fcfcd322c26081a1d8242e8"
   dependencies:
     async "~1.2.1"
     console-polyfill "0.3.0"
     debug "2.6.9"
     error-stack-parser "1.3.3"
-    extend "3.0.0"
     json-stringify-safe "~5.0.0"
     lru-cache "~2.2.1"
     request-ip "~2.0.1"


### PR DESCRIPTION
Follow up to https://github.com/goodeggs/rollbar-stream/pull/10 in which I tried the same thing but `yarn upgrade rollbar` didn't do what I intended